### PR TITLE
Back-sync Hashtable from remote PR #8

### DIFF
--- a/lib/Hashtable/README.md
+++ b/lib/Hashtable/README.md
@@ -164,11 +164,6 @@ return Iterator(this, TABLE_SIZE, nullptr);
 which is exactly what end() already has inside. This is just to be neater.
 
 - **v1.1.5**
-             - Hardened defensive behavior around edge cases in the Hashtable implementation.
-             - Improved compatibility and stability for defensive access paths and test coverage.
-             - Kept the existing capacity normalization and fallback behavior intact for safer embedded use.
-
-- **v1.1.4**
              - Added `normalizeTableSize()` private helper: zero or negative initial capacities now safely default to `INITIAL_TABLE_SIZE` instead of causing undefined behavior.
              - Fixed `Hashtable(size_t initialCapacity, float loadFactor)` constructor to pass capacity through `normalizeTableSize()`.
              - Fixed `resize()` to use the normalized size throughout, preventing zero-size allocations.
@@ -178,10 +173,13 @@ which is exactly what end() already has inside. This is just to be neater.
              - Fixed `operator[](const K& key)` (non-const): now safely returns a `static V dummy` fallback if the internal `get()` call returns `nullptr` after `put()`.
              - Fixed `operator[](const K& key) const`: now returns a stable `static const V defaultValue` reference instead of a dangling reference to a temporary.
 
+- **v1.1.4**
+             - Previous maintenance release.
+
 ---
 ## 📜 **Arduino Changelog**
 ### Latest Version:
-- **v1.0.5** [ON-PAR] -> PlatformIO v1.1.4
+- **v1.0.5** [ON-PAR] -> PlatformIO v1.1.5
              - Added `normalizeTableSize()` private helper: zero or negative initial capacities now safely default to `INITIAL_TABLE_SIZE`.
              - Fixed `Hashtable(size_t initialCapacity, float loadFactor)` constructor to use `normalizeTableSize()`.
              - Fixed `resize()` to use the normalized size, preventing zero-size allocations.

--- a/lib/Hashtable/src/Hashtable.h
+++ b/lib/Hashtable/src/Hashtable.h
@@ -3,6 +3,7 @@
 
 #include <SimpleVector.h>
 #include <Arduino.h>
+#include <limits.h>
 
 // Forward declaration of KeyHash
 /**
@@ -387,7 +388,7 @@ public:
      * 
     */
     Hashtable(size_t initialCapacity, float loadFactor) 
-        : TABLE_SIZE(normalizeTableSize(static_cast<int>(initialCapacity))), count(0), loadFactorThreshold(loadFactor), hashFunction() {
+        : TABLE_SIZE(normalizeTableSize(initialCapacity > static_cast<size_t>(INT_MAX) ? INT_MAX : static_cast<int>(initialCapacity))), count(0), loadFactorThreshold(loadFactor), hashFunction() {
         table = new Entry*[TABLE_SIZE]();
         // Initialize buckets to nullptr...
     }


### PR DESCRIPTION
Back-sync of **Hashtable** from remote PR [braydenanderson2014/ArduinoHashtable#8](https://github.com/braydenanderson2014/ArduinoHashtable/pull/8).

This pull request brings changes made by automated reviews back into the monorepo.

**Remote PR:** https://github.com/braydenanderson2014/ArduinoHashtable/pull/8
**Remote branch:** `sync-library/hashtable/issue-207`
**Remote head SHA:** `e16f4dd60a91ec429133446f424468dbc316237b`
**Source issue:** [braydenanderson2014/C-Arduino-Libraries#207](https://github.com/braydenanderson2014/C-Arduino-Libraries/issues/207)

<!-- library-back-sync-pr: source=braydenanderson2014/ArduinoHashtable#8;library=Hashtable;issueNumber=207;headSha=e16f4dd60a91ec429133446f424468dbc316237b;remoteBranch=sync-library/hashtable/issue-207 -->