### PR TITLE
Back-sync ArrayList from remote PR #5

### DIFF
--- a/lib/ArrayList/README.md
+++ b/lib/ArrayList/README.md
@@ -4,8 +4,8 @@ Reference version: `1.0.8-BETA`
 
 
 <!-- HEALTH_BADGES_START -->
-[![Health: Stable](https://img.shields.io/badge/Health-Stable-2ea44f?style=flat-square)](../../reports/library-health-report.md)
-[![Testing: Tested](https://img.shields.io/badge/Testing-Tested-2ea44f?style=flat-square)](../../reports/library-health-report.md)
+[![Health: Stable](https://img.shields.io/badge/Health-Stable-2ea44f?style=flat-square)](https://github.com/braydenanderson2014/C-Arduino-Libraries/blob/main/reports/library-health-report.md)
+[![Testing: Tested](https://img.shields.io/badge/Testing-Tested-2ea44f?style=flat-square)](https://github.com/braydenanderson2014/C-Arduino-Libraries/blob/main/reports/library-health-report.md)
 <!-- HEALTH_BADGES_END -->
 
 `ArrayList` is a templated container for Arduino projects with fixed-size and dynamically growing modes, bulk operations, iterators, sorting, cloning, and manual capacity controls for advanced use cases.


### PR DESCRIPTION
Back-sync of **ArrayList** from remote PR [braydenanderson2014/ArduinoArrayList#5](https://github.com/braydenanderson2014/ArduinoArrayList/pull/5).

This pull request brings changes made by automated reviews back into the monorepo.

**Remote PR:** https://github.com/braydenanderson2014/ArduinoArrayList/pull/5
**Remote branch:** `sync-library/arraylist/issue-250`
**Remote head SHA:** `478eac42c1b9aa903371a7ae0d3ab121135e0b04`
**Source issue:** [braydenanderson2014/C-Arduino-Libraries#250](https://github.com/braydenanderson2014/C-Arduino-Libraries/issues/250)

<!-- library-back-sync-pr: source=braydenanderson2014/ArduinoArrayList#5;library=ArrayList;issueNumber=250;headSha=478eac42c1b9aa903371a7ae0d3ab121135e0b04;remoteBranch=sync-library/arraylist/issue-250 -->